### PR TITLE
fix: resolve compilation issues on Qt 6.9

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dtklog (0.0.3) unstable; urgency=medium
+
+  * fix: resolve compilation issues on Qt 6.9
+
+ -- JiDe Zhang <zhangjide@deepin.org>  Fri, 12 Apr 2025 14:00:00 +0800
+
 dtklog (0.0.2) unstable; urgency=medium
 
   * release 0.0.2

--- a/src/FileAppender.cpp
+++ b/src/FileAppender.cpp
@@ -76,8 +76,8 @@ void FileAppender::setFileName(const QString &s)
 
     m_logFile.setFileName(s);
 
-    if (!spdlog::get(loggerName(s)))
-        rolling_logger_mt(loggerName(s),
+    if (!spdlog::get(loggerName(QFile(s))))
+        rolling_logger_mt(loggerName(QFile(s)),
                           m_logFile.fileName().toStdString(),
                           1024 * 1024 * 20, 0);
 }

--- a/src/RollingFileAppender.cpp
+++ b/src/RollingFileAppender.cpp
@@ -88,7 +88,7 @@ void RollingFileAppender::removeOldFiles()
 
 void RollingFileAppender::computeRollOverTime()
 {
-    if (auto *fs = get_sink<rolling_file_sink_mt>(loggerName(fileName())))
+    if (auto *fs = get_sink<rolling_file_sink_mt>(loggerName(QFile(fileName()))))
     {
         return fs->set_interval(RollingInterval(m_frequency));
     }
@@ -103,7 +103,7 @@ void RollingFileAppender::setLogFilesLimit(int limit)
     QMutexLocker locker(&m_rollingMutex);
     m_logFilesLimit = limit;
 
-    if (auto *fs = get_sink<rolling_file_sink_mt>(loggerName(fileName())))
+    if (auto *fs = get_sink<rolling_file_sink_mt>(loggerName(QFile(fileName()))))
     {
         return fs->set_max_files(std::size_t(limit));
     }
@@ -120,7 +120,7 @@ void RollingFileAppender::setLogSizeLimit(int limit)
     QMutexLocker locker(&m_rollingMutex);
     m_logSizeLimit = limit;
 
-    if (auto *fs = get_sink<rolling_file_sink_mt>(loggerName(fileName())))
+    if (auto *fs = get_sink<rolling_file_sink_mt>(loggerName(QFile(fileName()))))
     {
         return fs->set_max_size(std::size_t(limit));
     }


### PR DESCRIPTION
Adjusted the logger name retrieval in both FileAppender and RollingFileAppender classes to ensure compatibility with Qt 6.9. The changes involve replacing string parameters with QFile objects, which fixes the compilation errors that occurred under this version. These modifications improve the code's stability and ensure it adheres to the latest Qt standards, which is necessary for maintaining compatibility with future updates.

修复: 解决在 Qt 6.9 上的编译问题

调整了 FileAppender 和 RollingFileAppender 类中的日志记录器名称获取，以 确保与 Qt 6.9 的兼容性。更改涉及将字符串参数替换为 QFile 对象，从而修复
了在此版本下出现的编译错误。这些修改提高了代码的稳定性，并确保其遵循最新
的 Qt 标准，这对于维护与未来更新的兼容性是必要的。