### PR TITLE
fix: make version parameter optional in release workflow

### DIFF
--- a/.github/workflows/call-auto-release.yml
+++ b/.github/workflows/call-auto-release.yml
@@ -5,7 +5,7 @@ on:
       version:
         description: 'Release version (e.g., 1.0.0)'
         type: string
-        required: true
+        required: false
       name:
         description: 'The name of the person to release the version'
         type: string


### PR DESCRIPTION
Changed the version parameter from required to optional in the GitHub
Actions workflow. This provides more flexibility when triggering
releases, allowing the workflow to run without specifying a version if
needed for testing or other scenarios where version isn't immediately
available.

The workflow can now handle cases where versioning is determined
dynamically or when testing the release process without committing to a
specific version number.

fix: 在发布工作流中将版本参数设为可选

修改了GitHub Actions工作流中的版本参数，从必填改为可选。这为触发发布提供
了更大的灵活性，允许工作流在不指定版本的情况下运行，适用于测试或版本号尚
未确定的场景。

现在工作流可以处理动态确定版本号的情况，或者在不指定具体版本号的情况下测
试发布流程。
