### PR TITLE
feat: add appender unregistration methods

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -58,7 +58,3 @@ License: CC0-1.0
 Files: include/D*
 Copyright: None
 License: CC0-1.0
-
-Files: src/* include/*
-Copyright: UnionTech Software Technology Co., Ltd.
-License: LGPL-2.1-or-later

--- a/include/AbstractAppender.h
+++ b/include/AbstractAppender.h
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2010 Boris Moiseev (cyberbobs at gmail dot com)
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /*
   Copyright (c) 2010 Boris Moiseev (cyberbobs at gmail dot com)
 

--- a/include/AbstractStringAppender.h
+++ b/include/AbstractStringAppender.h
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2010 Boris Moiseev (cyberbobs at gmail dot com)
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /*
   Copyright (c) 2010 Boris Moiseev (cyberbobs at gmail dot com)
 

--- a/include/ConsoleAppender.h
+++ b/include/ConsoleAppender.h
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2010 Boris Moiseev (cyberbobs at gmail dot com)
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /*
   Copyright (c) 2010 Boris Moiseev (cyberbobs at gmail dot com)
 

--- a/include/FileAppender.h
+++ b/include/FileAppender.h
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2010 Boris Moiseev (cyberbobs at gmail dot com)
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /*
   Copyright (c) 2010 Boris Moiseev (cyberbobs at gmail dot com)
 

--- a/include/Logger.h
+++ b/include/Logger.h
@@ -1,5 +1,11 @@
+// SPDX-FileCopyrightText: 2012 Boris Moiseev (cyberbobs at gmail dot com)
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /*
   Copyright (c) 2012 Boris Moiseev (cyberbobs at gmail dot com)
+  Copyright (c) 2026 UnionTech Software Technology Co., Ltd.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU Lesser General Public License version 2.1
@@ -50,6 +56,9 @@ public:
 
   void registerAppender(AbstractAppender *appender);
   void registerCategoryAppender(const QString &category, AbstractAppender *appender);
+  
+  void unregisterAppender(AbstractAppender *appender);
+  void unregisterCategoryAppender(const QString &category, AbstractAppender *appender);
 
   QT_DEPRECATED_X("no longer take effect")
   void logToGlobalInstance(const QString &category, bool logToGlobal = false);

--- a/include/OutputDebugAppender.h
+++ b/include/OutputDebugAppender.h
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2010 Karl-Heinz Reichel (khreichel at googlemail dot com)
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /*
   Copyright (c) 2010 Karl-Heinz Reichel (khreichel at googlemail dot com)
 

--- a/include/RollingFileAppender.h
+++ b/include/RollingFileAppender.h
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /*
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU Lesser General Public License version 2.1

--- a/src/AbstractAppender.cpp
+++ b/src/AbstractAppender.cpp
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2010 Boris Moiseev (cyberbobs at gmail dot com)
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /*
   Copyright (c) 2010 Boris Moiseev (cyberbobs at gmail dot com)
 

--- a/src/AbstractStringAppender.cpp
+++ b/src/AbstractStringAppender.cpp
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2010 Boris Moiseev (cyberbobs at gmail dot com)
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /*
   Copyright (c) 2010 Boris Moiseev (cyberbobs at gmail dot com)
 

--- a/src/ConsoleAppender.cpp
+++ b/src/ConsoleAppender.cpp
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2010 Boris Moiseev (cyberbobs at gmail dot com)
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /*
   Copyright (c) 2010 Boris Moiseev (cyberbobs at gmail dot com)
 

--- a/src/FileAppender.cpp
+++ b/src/FileAppender.cpp
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2010 Boris Moiseev (cyberbobs at gmail dot com)
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /*
   Copyright (c) 2010 Boris Moiseev (cyberbobs at gmail dot com)
 

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -1,5 +1,11 @@
+// SPDX-FileCopyrightText: 2012 Boris Moiseev (cyberbobs at gmail dot com)
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /*
   Copyright (c) 2012 Boris Moiseev (cyberbobs at gmail dot com)
+  Copyright (c) 2026 UnionTech Software Technology Co., Ltd.
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU Lesser General Public License version 2.1
@@ -776,6 +782,27 @@ void Logger::registerAppender(AbstractAppender *appender)
 
 /*!
 @~english
+  @brief Unregisters the appender from the logger.
+
+  This removes the appender from the list of registered appenders.
+  The caller becomes responsible for managing the appender's lifetime.
+
+  @param[in] appender Appender to unregister
+
+  @note After unregistering, the Logger no longer owns the appender.
+        The caller must delete it manually to prevent memory leaks.
+
+  @sa registerAppender
+ */
+void Logger::unregisterAppender(AbstractAppender *appender)
+{
+    Q_D(Logger);
+    QMutexLocker locker(&d->loggerMutex);
+    d->appenders.removeOne(appender);
+}
+
+/*!
+@~english
   @brief Registers the appender to write the log records to the specific category.
 
   Calling this method, you can link some appender with the named category.
@@ -809,6 +836,28 @@ void Logger::registerCategoryAppender(const QString &category, AbstractAppender 
         d->categoryAppenders.insert(category, appender);
     else
         std::cerr << "Trying to register category [" << qPrintable(category) << "] appender that was already registered" << std::endl;
+}
+
+/*!
+@~english
+  @brief Unregisters the appender from the specific category.
+
+  This removes the appender from the list of category appenders.
+  The caller becomes responsible for managing the appender's lifetime.
+
+  @param[in] category Category name
+  @param[in] appender Appender to unregister
+
+  @note After unregistering, the Logger no longer owns the appender.
+        The caller must delete it manually to prevent memory leaks.
+
+  @sa registerCategoryAppender
+ */
+void Logger::unregisterCategoryAppender(const QString &category, AbstractAppender *appender)
+{
+    Q_D(Logger);
+    QMutexLocker locker(&d->loggerMutex);
+    d->categoryAppenders.remove(category, appender);
 }
 
 /*!

--- a/src/OutputDebugAppender.cpp
+++ b/src/OutputDebugAppender.cpp
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2010 Karl-Heinz Reichel (khreichel at googlemail dot com)
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /*
   Copyright (c) 2010 Karl-Heinz Reichel (khreichel at googlemail dot com)
 

--- a/src/RollingFileAppender.cpp
+++ b/src/RollingFileAppender.cpp
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /*
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU Lesser General Public License version 2.1


### PR DESCRIPTION
Added unregisterAppender and unregisterCategoryAppender methods to Logger class to allow proper cleanup of appender registrations. These methods remove appenders from the logger's internal lists and transfer ownership back to the caller, who becomes responsible for managing the appender's lifetime and preventing memory leaks. This is necessary for dynamic appender management scenarios where appenders need to be removed during runtime, such as when reconfiguring logging systems or shutting down components that use dedicated appenders.

feat: 添加日志输出器注销方法

为 Logger 类新增 unregisterAppender 和 unregisterCategoryAppender 方法， 以支持正确清理已注册的日志输出器。这些方法将输出器从日志记录器的内部列表
中移除，并将所有权交还给调用方，由调用方负责管理输出器的生命周期并防止内
存泄漏。这对于需要动态管理输出器的场景是必要的，例如在运行时重新配置日志
系统或关闭使用专用输出器的组件时。