### PR TITLE
fix: correct Upstream-Name and Source in .reuse/dep5

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,7 +1,7 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: dlog
+Upstream-Name: dtklog
 Upstream-Contact: UnionTech Software Technology Co., Ltd. <>
-Source: https://github.com/linuxdeepin/dlog
+Source: https://github.com/linuxdeepin/dtklog
 
 # Sample paragraph, commented out:
 #


### PR DESCRIPTION
## Summary
- Fix incorrect `Upstream-Name` in `.reuse/dep5` from `dlog` to `dtklog`
- Fix incorrect `Source` URL in `.reuse/dep5` from `linuxdeepin/dlog` to `linuxdeepin/dtklog`

Fixes #41