### PR TITLE
fix: replace QRegularExpression in qCleanupFuncinfo with byte-level scan

### DIFF
--- a/src/AbstractStringAppender.cpp
+++ b/src/AbstractStringAppender.cpp
@@ -18,11 +18,27 @@
 
 #include "AbstractStringAppender.h"
 
-#include <QRegularExpression>
 #include <QCoreApplication>
 #include <QThread>
 
 DLOG_CORE_BEGIN_NAMESPACE
+
+static bool removeLambdaSuffix(QByteArray *info)
+{
+    // Keep this dependency-light: it runs while logger/appender writes are serialized.
+    static constexpr char marker[] = "::<lambda(";
+    static constexpr int markerSize = sizeof(marker) - 1;
+    const int start = info->indexOf(marker);
+    if (start < 0)
+        return false;
+
+    const int end = info->lastIndexOf(")>");
+    if (end < start + markerSize)
+        return false;
+
+    info->remove(start, end + 2 - start);
+    return true;
+}
 
 inline static QString formattedLevelWithColor(Logger::LogLevel level, QString &msg)
 {
@@ -187,13 +203,8 @@ QByteArray AbstractStringAppender::qCleanupFuncinfo(const char *name)
     }
 
     bool hasLambda = false;
-    QRegularExpression lambdaRegex("::<lambda\\(.*\\)>");
-    QRegularExpressionMatch match = lambdaRegex.match(QString::fromLatin1(info));
-    if (match.hasMatch())
-    {
+    while (removeLambdaSuffix(&info))
         hasLambda = true;
-        info.remove(match.capturedStart(), match.capturedLength());
-    }
 
     // operator names with '(', ')', '<', '>' in it
     static const char operator_call[] = "operator()";


### PR DESCRIPTION
## Summary
- Replace `QRegularExpression`-based lambda suffix removal in `AbstractStringAppender::qCleanupFuncinfo` with a lightweight `QByteArray` indexOf/remove helper
- Remove the `QRegularExpression` include that was only used for this purpose
- The new `removeLambdaSuffix` does the same job with plain byte scans and is safe while appender writes are serialized

## Context
Coordinates with a companion change in dtkcore that avoids calling `qWarning` while holding `DSysInfoPrivate::mutex`, reducing reentrancy between the two libraries.

## Test plan
- [ ] Build dtklog (DTK5/Qt5) and dtk6log (DTK6/Qt6)
- [ ] Verify lambda function names are still stripped correctly in log output
- [ ] Verify non-lambda function names are unaffected

## Summary by Sourcery

Replace QRegularExpression-based lambda suffix stripping in qCleanupFuncinfo with a lightweight byte-level helper while keeping logger/appender dependencies minimal.

Enhancements:
- Introduce a dedicated removeLambdaSuffix helper that removes lambda suffixes from function info using QByteArray operations instead of regular expressions.

Chores:
- Drop the unused QRegularExpression include from AbstractStringAppender to reduce dependencies.