### PR TITLE
fix: Windows build compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,10 +90,18 @@ SET(library_target dtk${DTK_NAME_SUFFIX}log)
 
 ADD_LIBRARY(${library_target} SHARED ${sources} ${includes})
 
-TARGET_INCLUDE_DIRECTORIES(${library_target} PUBLIC
-  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
-  "$<INSTALL_INTERFACE:${INCLUDE_INSTALL_DIR}>"
-)
+IF(WIN32)
+  # On Windows, use include/ subdirectory to avoid VERSION file shadowing <version> header
+  TARGET_INCLUDE_DIRECTORIES(${library_target} PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:${INCLUDE_INSTALL_DIR}>"
+  )
+ELSE()
+  TARGET_INCLUDE_DIRECTORIES(${library_target} PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
+    "$<INSTALL_INTERFACE:${INCLUDE_INSTALL_DIR}>"
+  )
+ENDIF()
 
 TARGET_LINK_DIRECTORIES(${library_target} INTERFACE
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>"
@@ -114,10 +122,17 @@ if("${QT_VERSION_MAJOR}" STREQUAL "6")
   endif()
 endif()
 
-TARGET_LINK_LIBRARIES(${library_target} PRIVATE
-  Qt${QT_VERSION_MAJOR}::CorePrivate
-  spdlog::spdlog
-)
+IF(WIN32)
+  TARGET_LINK_LIBRARIES(${library_target} PRIVATE
+    Qt${QT_VERSION_MAJOR}::CorePrivate
+    spdlog::spdlog_header_only
+  )
+ELSE()
+  TARGET_LINK_LIBRARIES(${library_target} PRIVATE
+    Qt${QT_VERSION_MAJOR}::CorePrivate
+    spdlog::spdlog
+  )
+ENDIF()
 
 IF(BUILD_WITH_SYSTEMD)
   ADD_DEFINITIONS(-DBUILD_WITH_SYSTEMD)

--- a/src/OutputDebugAppender.cpp
+++ b/src/OutputDebugAppender.cpp
@@ -16,7 +16,11 @@
   GNU Lesser General Public License for more details.
 */
 // Local
+#ifdef _WIN32
+#include "OutputDebugAppender.h"
+#else
 #include "win32/OutputDebugAppender.h"
+#endif
 
 #include <spdlog/sinks/msvc_sink.h>
 #include <spdlog/spdlog.h>


### PR DESCRIPTION
- TARGET_INCLUDE_DIRECTORIES: use include/ subdirectory on Windows to prevent VERSION file (case-insensitive FS) from shadowing the C++20 <version> header
- spdlog linkage: use spdlog::spdlog_header_only on Windows to resolve multiple definition linker errors with spdlog shared library on MinGW
- OutputDebugAppender.cpp: add #ifdef _WIN32 guard for platform- specific include path